### PR TITLE
tasks: Add new influxdb repo key

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -15,16 +15,16 @@
 ## After version 2.2 of ansible 'listen' could be used to
 ## group 'check status' and 'assert running' into a single listener
 - name: check status
-  command: service telegraf status
-  args:
-    warn: false
+  ansible.builtin.command: service telegraf status
   ignore_errors: true
   register: telegraf_service_status
   become: true
   when: telegraf_start_service
+  listen: "check and assert running"
 
 - name: assert running
   assert:
     that:
       - "telegraf_service_status.rc == 0"
   when: telegraf_start_service
+  listen: "check and assert running"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -25,8 +25,7 @@
   notify:
     - "restart telegraf"
     - "pause"
-    - "check status"
-    - "assert running"
+    - "check and assert running"
 
 - name: Test for sysvinit script
   stat:

--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -8,6 +8,12 @@
     mode: 0644
   when: telegraf_install_url is not defined or telegraf_install_url == None
 
+# https://www.influxdata.com/blog/linux-package-signing-key-rotation/
+- name: Add updated influxdb repo key
+  ansible.builtin.rpm_key:
+    key: https://repos.influxdata.com/influxdata-archive_compat.key
+    state: present
+
 - name: Install Telegraf packages [RHEL/CentOS]
   yum:
     name: telegraf

--- a/tasks/start.yml
+++ b/tasks/start.yml
@@ -7,6 +7,5 @@
   # Only care to check the status if the state changed to 'started'
   notify:
     - "pause"
-    - "check status"
-    - "assert running"
+    - "check and assert running"
   become: true


### PR DESCRIPTION
The old influxdb repo key was rotated and is not currently present on f39 vm. We must manually add this key. See https://www.influxdata.com/blog/linux-package-signing-key-rotation/